### PR TITLE
travis: upgrade to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - 1.10.x
+  - 1.11.x
 install:
   - nvm install 9.11
   - npm install -g source-map-support


### PR DESCRIPTION
This upgrades us to Go 1.11 on CI.