### PR TITLE
Move Vecty from gopherjs/vecty → hexops/vecty

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ issues:
 
   # List of regexps of issue texts to exclude, empty list by default.
   exclude:
-    # https://github.com/gopherjs/vecty/issues/226
+    # https://github.com/hexops/vecty/issues/226
     - "comment on exported function Timeout should be of the form"
 
     # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ script:
 
   # Consult golangci-lint (multiple Go linting tools).
   - golangci-lint run . ./elem/... ./event/...
-  - golangci-lint run --exclude 'exported .* should have comment .*or be unexported' ./prop/... ./style/... # https://github.com/gopherjs/vecty/issues/227
+  - golangci-lint run --exclude 'exported .* should have comment .*or be unexported' ./prop/... ./style/... # https://github.com/hexops/vecty/issues/227
   - GOOS=js GOARCH=wasm golangci-lint run --build-tags 'js wasm' . ./elem/... ./event/...
-  - GOOS=js GOARCH=wasm golangci-lint run --build-tags 'js wasm' --exclude 'exported .* should have comment .*or be unexported' ./prop/... ./style/... # https://github.com/gopherjs/vecty/issues/227
+  - GOOS=js GOARCH=wasm golangci-lint run --build-tags 'js wasm' --exclude 'exported .* should have comment .*or be unexported' ./prop/... ./style/... # https://github.com/hexops/vecty/issues/227
   - bash -c 'cd example && golangci-lint run ./markdown'
   - bash -c 'cd example && GOOS=js GOARCH=wasm golangci-lint run --build-tags 'js wasm' ./...'
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Vecty is a library for building responsive and dynamic web frontends in Go instead of in JavaScript, HTML & CSS. It competes with modern web frameworks like React & VueJS, and supports compilation to both WebAssembly and vanilla JavaScript.
 
-[![Build Status](https://travis-ci.org/gopherjs/vecty.svg?branch=master)](https://travis-ci.org/gopherjs/vecty) [![GoDoc](https://godoc.org/github.com/gopherjs/vecty?status.svg)](https://godoc.org/github.com/gopherjs/vecty) [![codecov](https://img.shields.io/codecov/c/github/gopherjs/vecty/master.svg)](https://codecov.io/gh/gopherjs/vecty)
+[![Build Status](https://travis-ci.org/hexops/vecty.svg?branch=master)](https://travis-ci.org/hexops/vecty) [![GoDoc](https://godoc.org/github.com/hexops/vecty?status.svg)](https://godoc.org/github.com/hexops/vecty) [![codecov](https://img.shields.io/codecov/c/github/hexops/vecty/master.svg)](https://codecov.io/gh/hexops/vecty)
 
 Benefits
 ========
@@ -35,7 +35,7 @@ Features
 Current Status
 ==============
 
-**Vecty is currently considered to be an experimental work-in-progress.** Prior to widespread production use, we must meet our [v1.0.0 milestone](https://github.com/gopherjs/vecty/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0) goals, which are being completed slowly and steadily as contributors have time (Vecty is over 4 years in the making!).
+**Vecty is currently considered to be an experimental work-in-progress.** Prior to widespread production use, we must meet our [v1.0.0 milestone](https://github.com/hexops/vecty/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0) goals, which are being completed slowly and steadily as contributors have time (Vecty is over 4 years in the making!).
 
 Early adopters may make use of it for real applications today as long as they are understanding and accepting of the fact that:
 
@@ -45,9 +45,9 @@ Early adopters may make use of it for real applications today as long as they ar
 	- URL-based component routing
 	- Ready-to-use component libraries (e.g. material UI)
 	- Server-side rendering
-	- And more, see [milestone: v1.0.0 ](https://github.com/gopherjs/vecty/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0)
+	- And more, see [milestone: v1.0.0 ](https://github.com/hexops/vecty/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0)
 - The scope of Vecty is only ~80% defined currently.
-- There are a number of important [open issues](https://github.com/gopherjs/vecty/issues).
+- There are a number of important [open issues](https://github.com/hexops/vecty/issues).
 
 For a list of projects currently using Vecty, see the [doc/projects-using-vecty.md](doc/projects-using-vecty.md) file.
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,37 +1,37 @@
 Changelog
 =========
 
-Although v1.0.0 [is not yet out](https://github.com/gopherjs/vecty/milestone/1), we do not expect many breaking changes. When there is one, however, it is documented clearly here.
+Although v1.0.0 [is not yet out](https://github.com/hexops/vecty/milestone/1), we do not expect many breaking changes. When there is one, however, it is documented clearly here.
 
 Pre-v1.0.0 Breaking Changes
 ---------------------------
 
-## August 15, 2020 ([PR #265](https://github.com/gopherjs/vecty/pull/265)): Deprecated and removed official support for GopherJS
+## August 15, 2020 ([PR #265](https://github.com/hexops/vecty/pull/265)): Deprecated and removed official support for GopherJS
 
-For more information please see [issue #264](https://github.com/gopherjs/vecty/issues/264).
+For more information please see [issue #264](https://github.com/hexops/vecty/issues/264).
 
 If your application cannot compile wihtout GopherJS, you may continue to use the tag `v0.5.0` which is the last version of Vecty which officially supported GopherJS at the time.
 
 New versions of Vecty _may_ compile with GopherJS, but we do not officially support it and it is dependent on GopherJS being compatible with the official Go compiler.
 
-## February 28, 2020 ([PR #256](https://github.com/gopherjs/vecty/pull/256)): indirect breaking change
+## February 28, 2020 ([PR #256](https://github.com/hexops/vecty/pull/256)): indirect breaking change
 
 - Go 1.14+ is now required by Vecty. Users of older Go versions and/or GopherJS (until https://github.com/gopherjs/gopherjs/issues/962 is fixed) may wish to continue using commit `6a0a25ee5a96ce029e684c7da6333aa1f34f8f96`.
 
-## Nov 30, 2019 ([PR #249](https://github.com/gopherjs/vecty/pull/249)): minor breaking change
+## Nov 30, 2019 ([PR #249](https://github.com/hexops/vecty/pull/249)): minor breaking change
 
 - `vecty.RenderBody(comp)` is now a blocking function call. Users that rely on it being non-blocking can instead now use `if err := vecty.RenderInto("body", comp); err != nil { panic(err) }`
 
-## June 30, 2019 ([PR #232](https://github.com/gopherjs/vecty/pull/232)): major breaking change
+## June 30, 2019 ([PR #232](https://github.com/hexops/vecty/pull/232)): major breaking change
 
 - `(*HTML).Node` now returns a `syscall/js.Value` instead of `*gopherjs/js.Object`. Users will need to update to the new `syscall/js` API in their applications.
 - Go 1.12+ is now required by Vecty, as we make use of [synchronous callback support](https://go-review.googlesource.com/c/go/+/142004) not present in earlier versions.
 
-## May 25, 2019 ([PR #235](https://github.com/gopherjs/vecty/pull/235)): minor breaking change
+## May 25, 2019 ([PR #235](https://github.com/hexops/vecty/pull/235)): minor breaking change
 
 - `prop.TypeUrl` has been renamed to `prop.TypeURL`.
 
-## Nov 4, 2017 ([PR #158](https://github.com/gopherjs/vecty/pull/158)): major breaking change
+## Nov 4, 2017 ([PR #158](https://github.com/hexops/vecty/pull/158)): major breaking change
 
 All `Component`s must now have a `Render` method which returns `vecty.ComponentOrHTML` instead of the prior `*vecty.HTML` type.
 
@@ -56,20 +56,20 @@ git grep -l ') Render() \*vecty.HTML' | xargs sed -i '' -e 's/) Render() \*vecty
 
 Obviously, you'll still need to verify that this only modifies your `Component` implementations. No other changes are needed, and no behavior change is expected for components that return `*vecty.HTML` (as the new `vecty.ComponentOrHTML` interface return type).
 
-## Oct 14, 2017 ([PR #155](https://github.com/gopherjs/vecty/pull/155)): major breaking change
+## Oct 14, 2017 ([PR #155](https://github.com/hexops/vecty/pull/155)): major breaking change
 
 The function `prop.Class(string)` has been removed and replaced with `vecty.Class(...string)`.  Migrating users must use the new function and split their classes into separate strings, rather than a single space-separated string.
 
-## Oct 1, 2017 ([PR #147](https://github.com/gopherjs/vecty/pull/147)): minor breaking change
+## Oct 1, 2017 ([PR #147](https://github.com/hexops/vecty/pull/147)): minor breaking change
 
 `MarkupOrChild` and `ComponentOrHTML` can both now contain `KeyedList` (a new type that has been added)
 
-## Sept 5, 2017 ([PR #140](https://github.com/gopherjs/vecty/pull/140)): minor breaking change
+## Sept 5, 2017 ([PR #140](https://github.com/hexops/vecty/pull/140)): minor breaking change
 
-Package `storeutil` has been moved to `github.com/gopherjs/vecty/example/todomvc/store/storeutil` import path.
+Package `storeutil` has been moved to `github.com/hexops/vecty/example/todomvc/store/storeutil` import path.
 
 
-## Sept 2, 2017 ([PR #134](https://github.com/gopherjs/vecty/pull/134)): major breaking change
+## Sept 2, 2017 ([PR #134](https://github.com/hexops/vecty/pull/134)): major breaking change
 
 Several breaking changes have been made. Below, we describe how to upgrade your Vecty code to reflect each of these changes.
 
@@ -124,16 +124,16 @@ func (p *PageView) Render() *vecty.HTML {
 - The `Markup` _interface_ has been renamed to `Applyer`, and a `Markup` _function_ has been added to create a `MarkupList`.
 
 
-## Aug 6, 2017 ([PR #130](https://github.com/gopherjs/vecty/pull/130)): minor breaking change
+## Aug 6, 2017 ([PR #130](https://github.com/hexops/vecty/pull/130)): minor breaking change
 
 The `Restorer` interface has been removed, component instances are now persistent. Properties should be denoted via ``` `vecty:"prop"` ``` struct field tags.
 
 
-## Jun 17, 2017 ([PR #117](https://github.com/gopherjs/vecty/pull/117)): minor breaking change
+## Jun 17, 2017 ([PR #117](https://github.com/hexops/vecty/pull/117)): minor breaking change
 
 `(*HTML).Restore` is no longer exported, this method was not generally used externally.
 
 
-## May 11, 2017 ([PR #108](https://github.com/gopherjs/vecty/pull/108)): minor breaking change
+## May 11, 2017 ([PR #108](https://github.com/hexops/vecty/pull/108)): minor breaking change
 
 `(*HTML).Node` is now a function instead of a struct field.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,13 +6,28 @@ Although v1.0.0 [is not yet out](https://github.com/hexops/vecty/milestone/1), w
 Pre-v1.0.0 Breaking Changes
 ---------------------------
 
-## August 15, 2020 ([PR #265](https://github.com/hexops/vecty/pull/265)): Deprecated and removed official support for GopherJS
+## August 15, 2020 ([PR #266](https://github.com/hexops/vecty/pull/266)): minor breaking change
 
-For more information please see [issue #264](https://github.com/hexops/vecty/issues/264).
+Vecty has moved to the [github.com/hexops](https://github.com/hexops) organization. Update your import paths:
 
-If your application cannot compile wihtout GopherJS, you may continue to use the tag `v0.5.0` which is the last version of Vecty which officially supported GopherJS at the time.
+```diff
+-import "github.com/gopherjs/vecty"
++import "github.com/hexops/vecty"
+```
+
+And update your `go.mod` as required.
+
+For more information see [issue #230](https://github.com/hexops/vecty/issues/230#issuecomment-674474753).
+
+## August 15, 2020 ([PR #265](https://github.com/hexops/vecty/pull/265)): minor breaking change
+
+Deprecated and removed official support for GopherJS.
 
 New versions of Vecty _may_ compile with GopherJS, but we do not officially support it and it is dependent on GopherJS being compatible with the official Go compiler.
+
+If your application cannot compile without GopherJS, you may continue to use the tag `v0.5.0` which is the last version of Vecty which officially supported GopherJS at the time.
+
+For more information please see [issue #264](https://github.com/hexops/vecty/issues/264).
 
 ## February 28, 2020 ([PR #256](https://github.com/hexops/vecty/pull/256)): indirect breaking change
 

--- a/doc/projects-using-vecty.md
+++ b/doc/projects-using-vecty.md
@@ -1,4 +1,4 @@
-# Projects using [Vecty](https://github.com/gopherjs/vecty)
+# Projects using [Vecty](https://github.com/hexops/vecty)
 
 The following projects use Vecty to render their frontend in some capacity.
 
@@ -11,4 +11,4 @@ This is just a list of applications using Vecty that we're aware of. We don't st
 | [qlql](https://github.com/gernest/qlql) | A GUI management tool for the [ql database](https://github.com/cznic/ql). |
 | [marwan.io](https://www.marwan.io/) | A portfolio website by Marwan Sulaiman. |
 
-Know of a project using Vecty that is not on this list? Please [let us know](https://github.com/gopherjs/vecty/issues/new)!
+Know of a project using Vecty that is not on this list? Please [let us know](https://github.com/hexops/vecty/issues/new)!

--- a/dom.go
+++ b/dom.go
@@ -59,7 +59,7 @@ type Component interface {
 // implement the Copier interface, a shallow copy is performed.
 //
 // TinyGo: If compiling your Vecty application using the experimental TinyGo
-// support (https://github.com/gopherjs/vecty/pull/243) then all components must
+// support (https://github.com/hexops/vecty/pull/243) then all components must
 // implement at least a shallow-copy Copier interface (this is not required
 // otherwise):
 //

--- a/dom_test.go
+++ b/dom_test.go
@@ -332,7 +332,7 @@ func TestHTML_reconcile_std(t *testing.T) {
 	})
 
 	// TODO(pdf): test (*HTML).reconcile child mutations, and value/checked properties
-	// TODO(pdf): test multi-pass reconcile of persistent component pointer children, ref: https://github.com/gopherjs/vecty/pull/124
+	// TODO(pdf): test multi-pass reconcile of persistent component pointer children, ref: https://github.com/hexops/vecty/pull/124
 }
 
 // TestHTML_reconcile_nil tests that (*HTML).reconcile(nil) works as expected (i.e.

--- a/dom_tinygo.go
+++ b/dom_tinygo.go
@@ -26,12 +26,12 @@ func init() {
 // 		at runtime.runtimePanic (http://localhost:8081/main.wasm:wasm-function[61]:0x4472)
 // 		at runtime.nilPanic (http://localhost:8081/main.wasm:wasm-function[46]:0x3277)
 // 		at runtime.hashmapNext (http://localhost:8081/main.wasm:wasm-function[83]:0x5881)
-// 		at (*github.com/gopherjs/vecty.HTML).reconcileProperties (http://localhost:8081/main.wasm:wasm-function[198]:0x117f4)
-// 		at (*github.com/gopherjs/vecty.HTML).reconcile (http://localhost:8081/main.wasm:wasm-function[175]:0xda6c)
-// 		at github.com/gopherjs/vecty.renderComponent (http://localhost:8081/main.wasm:wasm-function[176]:0xf00d)
-// 		at github.com/gopherjs/vecty.renderIntoNode (http://localhost:8081/main.wasm:wasm-function[153]:0xbbe3)
-// 		at github.com/gopherjs/vecty.RenderBody (http://localhost:8081/main.wasm:wasm-function[147]:0xb4a8)
-// 		at github.com/gopherjs/vecty/example/hellovecty.main (http://localhost:8081/main.wasm:wasm-function[107]:0x6e36)
+// 		at (*github.com/hexops/vecty.HTML).reconcileProperties (http://localhost:8081/main.wasm:wasm-function[198]:0x117f4)
+// 		at (*github.com/hexops/vecty.HTML).reconcile (http://localhost:8081/main.wasm:wasm-function[175]:0xda6c)
+// 		at github.com/hexops/vecty.renderComponent (http://localhost:8081/main.wasm:wasm-function[176]:0xf00d)
+// 		at github.com/hexops/vecty.renderIntoNode (http://localhost:8081/main.wasm:wasm-function[153]:0xbbe3)
+// 		at github.com/hexops/vecty.RenderBody (http://localhost:8081/main.wasm:wasm-function[147]:0xb4a8)
+// 		at github.com/hexops/vecty/example/hellovecty.main (http://localhost:8081/main.wasm:wasm-function[107]:0x6e36)
 // 		at runtime.run$1 (http://localhost:8081/main.wasm:wasm-function[55]:0x40c6)
 //
 func (h *HTML) tinyGoCannotIterateNilMaps() {

--- a/elem/elem.gen.go
+++ b/elem/elem.gen.go
@@ -7,7 +7,7 @@
 // CC-BY-SA 2.5.
 package elem
 
-import "github.com/gopherjs/vecty"
+import "github.com/hexops/vecty"
 
 // Anchor (or anchor element) creates a hyperlink to other web pages, files,
 // locations within the same page, email addresses, or any other URL.

--- a/elem/generate.go
+++ b/elem/generate.go
@@ -105,7 +105,7 @@ func main() {
 // CC-BY-SA 2.5.
 package elem
 
-import "github.com/gopherjs/vecty"
+import "github.com/hexops/vecty"
 `)
 
 	doc.Find(".quick-links a").Each(func(i int, s *goquery.Selection) {

--- a/event/event.gen.go
+++ b/event/event.gen.go
@@ -7,7 +7,7 @@
 // CC-BY-SA 2.5.
 package event
 
-import "github.com/gopherjs/vecty"
+import "github.com/hexops/vecty"
 
 // Abort is an event fired when a transaction has been aborted.
 //

--- a/event/generate.go
+++ b/event/generate.go
@@ -185,7 +185,7 @@ func main() {
 // CC-BY-SA 2.5.
 package event
 
-import "github.com/gopherjs/vecty"
+import "github.com/hexops/vecty"
 `)
 
 	for _, name := range names {

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,11 +1,13 @@
-module github.com/gopherjs/vecty/example
+module github.com/hexops/vecty/example
 
 go 1.12
 
-replace github.com/gopherjs/vecty => ../
+replace github.com/hexops/vecty => ../
 
 require (
-	github.com/gopherjs/vecty v0.0.0-20190121070609-2a1e317a95ae
+	github.com/gopherjs/vecty v0.5.0
+	github.com/gopherjs/vecty/example v0.0.0-20200816034955-3654578c562f
+	github.com/hexops/vecty v0.5.0
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/slimsag/blackfriday v2.0.0+incompatible

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,3 +1,9 @@
+github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/vecty v0.0.0-20190121070609-2a1e317a95ae/go.mod h1:cCfq26X9MMEw/ZgZRpDDNSWfC7CO/u2ba/nGpjEVM/o=
+github.com/gopherjs/vecty v0.5.0 h1:pnaU0yIo0sT3WlDXi22WA9FNhwiswnHb+1mbS8wISW4=
+github.com/gopherjs/vecty v0.5.0/go.mod h1:Yd9AOfl6lN1BWnVnvaSBwKiTCAcnlIGGvdsODOOZ9RY=
+github.com/gopherjs/vecty/example v0.0.0-20200816034955-3654578c562f h1:kGiszhEj/NRS3gHksxoExkCniA41aabKQpwfLdFZbYw=
+github.com/gopherjs/vecty/example v0.0.0-20200816034955-3654578c562f/go.mod h1:Q+pviq0v9oAECJMu9Ti/nfy2UlaZ90hTlbo2EzOH/I4=
 github.com/microcosm-cc/bluemonday v1.0.2 h1:5lPfLTTAvAbtS0VqT+94yOtFnGfUWYyx0+iToC3Os3s=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=

--- a/example/hellovecty/hellovecty.go
+++ b/example/hellovecty/hellovecty.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/gopherjs/vecty"
-	"github.com/gopherjs/vecty/elem"
+	"github.com/hexops/vecty"
+	"github.com/hexops/vecty/elem"
 )
 
 func main() {

--- a/example/markdown/markdown.go
+++ b/example/markdown/markdown.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/gopherjs/vecty"
-	"github.com/gopherjs/vecty/elem"
-	"github.com/gopherjs/vecty/event"
+	"github.com/hexops/vecty"
+	"github.com/hexops/vecty/elem"
+	"github.com/hexops/vecty/event"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/slimsag/blackfriday"
 )

--- a/example/todomvc/actions/actions.go
+++ b/example/todomvc/actions/actions.go
@@ -1,6 +1,6 @@
 package actions
 
-import "github.com/gopherjs/vecty/example/todomvc/store/model"
+import "github.com/hexops/vecty/example/todomvc/store/model"
 
 // ReplaceItems is an action that replaces all items with the specified ones.
 type ReplaceItems struct {

--- a/example/todomvc/components/filterbutton.go
+++ b/example/todomvc/components/filterbutton.go
@@ -1,14 +1,14 @@
 package components
 
 import (
-	"github.com/gopherjs/vecty"
-	"github.com/gopherjs/vecty/elem"
-	"github.com/gopherjs/vecty/event"
-	"github.com/gopherjs/vecty/example/todomvc/actions"
-	"github.com/gopherjs/vecty/example/todomvc/dispatcher"
-	"github.com/gopherjs/vecty/example/todomvc/store"
-	"github.com/gopherjs/vecty/example/todomvc/store/model"
-	"github.com/gopherjs/vecty/prop"
+	"github.com/hexops/vecty"
+	"github.com/hexops/vecty/elem"
+	"github.com/hexops/vecty/event"
+	"github.com/hexops/vecty/example/todomvc/actions"
+	"github.com/hexops/vecty/example/todomvc/dispatcher"
+	"github.com/hexops/vecty/example/todomvc/store"
+	"github.com/hexops/vecty/example/todomvc/store/model"
+	"github.com/hexops/vecty/prop"
 )
 
 // FilterButton is a vecty.Component which allows the user to select a filter

--- a/example/todomvc/components/itemview.go
+++ b/example/todomvc/components/itemview.go
@@ -1,14 +1,14 @@
 package components
 
 import (
-	"github.com/gopherjs/vecty"
-	"github.com/gopherjs/vecty/elem"
-	"github.com/gopherjs/vecty/event"
-	"github.com/gopherjs/vecty/example/todomvc/actions"
-	"github.com/gopherjs/vecty/example/todomvc/dispatcher"
-	"github.com/gopherjs/vecty/example/todomvc/store/model"
-	"github.com/gopherjs/vecty/prop"
-	"github.com/gopherjs/vecty/style"
+	"github.com/hexops/vecty"
+	"github.com/hexops/vecty/elem"
+	"github.com/hexops/vecty/event"
+	"github.com/hexops/vecty/example/todomvc/actions"
+	"github.com/hexops/vecty/example/todomvc/dispatcher"
+	"github.com/hexops/vecty/example/todomvc/store/model"
+	"github.com/hexops/vecty/prop"
+	"github.com/hexops/vecty/style"
 )
 
 // ItemView is a vecty.Component which represents a single item in the TODO

--- a/example/todomvc/components/pageview.go
+++ b/example/todomvc/components/pageview.go
@@ -3,15 +3,15 @@ package components
 import (
 	"strconv"
 
-	"github.com/gopherjs/vecty"
-	"github.com/gopherjs/vecty/elem"
-	"github.com/gopherjs/vecty/event"
-	"github.com/gopherjs/vecty/example/todomvc/actions"
-	"github.com/gopherjs/vecty/example/todomvc/dispatcher"
-	"github.com/gopherjs/vecty/example/todomvc/store"
-	"github.com/gopherjs/vecty/example/todomvc/store/model"
-	"github.com/gopherjs/vecty/prop"
-	"github.com/gopherjs/vecty/style"
+	"github.com/hexops/vecty"
+	"github.com/hexops/vecty/elem"
+	"github.com/hexops/vecty/event"
+	"github.com/hexops/vecty/example/todomvc/actions"
+	"github.com/hexops/vecty/example/todomvc/dispatcher"
+	"github.com/hexops/vecty/example/todomvc/store"
+	"github.com/hexops/vecty/example/todomvc/store/model"
+	"github.com/hexops/vecty/prop"
+	"github.com/hexops/vecty/style"
 )
 
 // PageView is a vecty.Component which represents the entire page.

--- a/example/todomvc/example.go
+++ b/example/todomvc/example.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"syscall/js"
 
-	"github.com/gopherjs/vecty"
-	"github.com/gopherjs/vecty/example/todomvc/actions"
-	"github.com/gopherjs/vecty/example/todomvc/components"
-	"github.com/gopherjs/vecty/example/todomvc/dispatcher"
-	"github.com/gopherjs/vecty/example/todomvc/store"
-	"github.com/gopherjs/vecty/example/todomvc/store/model"
+	"github.com/hexops/vecty"
+	"github.com/hexops/vecty/example/todomvc/actions"
+	"github.com/hexops/vecty/example/todomvc/components"
+	"github.com/hexops/vecty/example/todomvc/dispatcher"
+	"github.com/hexops/vecty/example/todomvc/store"
+	"github.com/hexops/vecty/example/todomvc/store/model"
 )
 
 func main() {

--- a/example/todomvc/store/store.go
+++ b/example/todomvc/store/store.go
@@ -1,10 +1,10 @@
 package store
 
 import (
-	"github.com/gopherjs/vecty/example/todomvc/actions"
-	"github.com/gopherjs/vecty/example/todomvc/dispatcher"
-	"github.com/gopherjs/vecty/example/todomvc/store/model"
-	"github.com/gopherjs/vecty/example/todomvc/store/storeutil"
+	"github.com/hexops/vecty/example/todomvc/actions"
+	"github.com/hexops/vecty/example/todomvc/dispatcher"
+	"github.com/hexops/vecty/example/todomvc/store/model"
+	"github.com/hexops/vecty/example/todomvc/store/storeutil"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gopherjs/vecty
+module github.com/hexops/vecty
 
 go 1.12

--- a/prop/prop.go
+++ b/prop/prop.go
@@ -1,6 +1,6 @@
 package prop
 
-import "github.com/gopherjs/vecty"
+import "github.com/hexops/vecty"
 
 type InputType string
 

--- a/require_go_1_14.go
+++ b/require_go_1_14.go
@@ -4,7 +4,7 @@ package vecty
 
 // Typechecking will pass except one error:
 //
-// 	# github.com/gopherjs/vecty
+// 	# github.com/hexops/vecty
 // 	../../require_go_1_14.go:7:2: undefined: VECTY_REQUIRES_GO_1_14_PLUS
 //
 

--- a/style/style.go
+++ b/style/style.go
@@ -3,7 +3,7 @@ package style
 import (
 	"strconv"
 
-	"github.com/gopherjs/vecty"
+	"github.com/hexops/vecty"
 )
 
 type Size string


### PR DESCRIPTION
This PR moves Vecty from the github.com/gopherjs/vecty organization to github.com/hexops/vecty.

For more information, see https://github.com/hexops/vecty/issues/230#issuecomment-674474753

Import paths will need to be updated, please refer to the [CHANGELOG](https://github.com/hexops/vecty/blob/master/doc/CHANGELOG.md)

Closes https://github.com/hexops/vecty/issues/230