### PR TITLE
example: update README to reflect TinyGo and GopherJS compiler support

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,13 +1,10 @@
 # Building examples
 
-Vecty fully supports two major Go <-> Web compilers thanks to its minimal dependencies:
+Vecty examples can be built with the Go 1.14+ WebAssembly compilation target.
 
-- Go 1.14+ WebAssembly support
-- [GopherJS](https://github.com/gopherjs/gopherjs) (Go to JavaScript transpiler)
+Additionally, Vecty has [experimental support for the TinyGo compiler]().
 
-If you are just getting started, we suggest using the Go 1.14+ WebAssembly support.
-
-## Go 1.14+ WebAssembly support
+## Building for WebAssembly with Go 1.14+
 
 **Ensure you are running Go 1.14 or higher.** Vecty requires Go 1.14+ as it makes use of improvements to the `syscall/js` package which are not present in earlier versions of Go.
 
@@ -24,25 +21,18 @@ go get -u github.com/hajimehoshi/wasmserve
 Then run an example:
 
 ```bash
-cd markdown/
+cd example/markdown/
 wasmserve
 ```
 
-And navigate to http://localhost:8080/
+Then navigate to http://localhost:8080/
 
-# GopherJS
+## Building for TinyGo
 
-### Running examples
+TinyGo support is in very early stages still. Please refer to https://github.com/hexops/vecty/issues/269
 
-Install [GopherJS](https://github.com/gopherjs/gopherjs#installation-and-usage) then run an example:
+## Building with other Go compilers
 
-```bash
-cd markdown
-gopherjs serve
-```
+Other compilers such as [GopherJS](https://github.com/gopherjs) may work so long as they are compliant with the official Go 1.14+ compiler (support modules, the `syscall/js` interface, reflection, etc.)
 
-And navigate to http://localhost:8080/
-
-## TinyGo WebAssembly support
-
-[TinyGo](https://github.com/tinygo-org/tinygo) WebAssembly support is [being actively worked on](https://github.com/tinygo-org/tinygo/issues/93).
+Vecty currently can only be built to run in web browsers.


### PR DESCRIPTION
Updates the `example/README.md` to reflect the latest changes in [experimental TinyGo support](https://github.com/hexops/vecty/issues/269) and [deprecation/removal of GopherJS support](https://github.com/hexops/vecty/issues/264).