### PR TITLE
README: update bundle sizes, clarify what bundle sizes mean

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,19 @@ Early adopters may make use of it for real applications today as long as they ar
 
 For a list of projects currently using Vecty, see the [doc/projects-using-vecty.md](doc/projects-using-vecty.md) file.
 
-Small bundle sizes
-==================
+Near-zero dependencies
+======================
 
-Vecty uses extremely minimal dependencies and prides itself on producing very small bundle sizes (mostly limited by the compiler), making it suitable for modern web development:
+Vecty has nearly zero dependencies, it only relies on `reflect` from the Go stdlib. Through this, it is able to produce the smallest bundle sizes for Go frontend applications out there, limited only by the Go compiler itself:
 
-| Example      | Compiler                | Bundle size | Compressed (gzip) |
-|--------------|-------------------------|-------------|-------------------|
-| `hellovecty` | Go + WebAssembly        | 2.3 MB      | 0.5 MB            |
-| `markdown`   | Go + WebAssembly        | 4.2 MB      | 0.9 MB            |
-| `todomvc`    | Go + WebAssembly        | 3.4 MB      | 0.7 MB            |
+| Example binary    | Compiler        | uncompressed | `gzip --best` | `brotli` |
+|-------------------|-----------------|--------------|---------------|----------|
+| `hellovecty.wasm` | `tinygo 0.14.0` | 252K         | 97K           | 81K      |
+| `hellovecty.wasm` | `go 1.15`       | 2.1M         | 587K          | 443K     |
+| `markdown.wasm`   | `go 1.15`       | 3.6M         | 1010K         | 745K     |
+| `todomvc.wasm`    | `go 1.15`       | 2.9M         | 825K          | 617K     |
+
+Note: Bundle sizes above do not scale linearly with more code/dependencies in your Vecty project. `hellovecty` is the smallest base-line bundle that the compiler can produce with just Vecty as a dependency, other examples above pull in more of the Go standard library and you would not e.g. have to pay that total cost again.
 
 Community
 =========

--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -182,7 +182,7 @@ func (ts *testSuiteT) multiSortedDone(linesToSort ...[2]int) {
 
 	// Write what we got to disk.
 	gotFileName := path.Join("testdata", testName+".got.txt")
-	err = ioutil.WriteFile(gotFileName, []byte(got), 0777)
+	err = ioutil.WriteFile(gotFileName, []byte(got), 0o777)
 	if err != nil {
 		ts.t.Error(err)
 		return


### PR DESCRIPTION
- Add TinyGo bundle sizes which shows the clear benefit of TinyGo.
- Updates numbers to Go 1.15 compiler, which produces much smaller bundles.
- Add brotli compression numbers.
- Clarify that these numbers are baseline and do not scale linearly with dependencies.
- Change "Small bundle sizes" to "Near-zero dependencies" to clarify we (on the Vecty side)
  are doing everything we can and majority of the size comes from the Go compilers. Also,
  this eliminates anyone's concern about "several MB is small?!" (which it's not.)